### PR TITLE
add flags -a or --all for listing all the saved groups

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -10,6 +10,7 @@ import (
 
 type listOptions struct {
 	filterByTag string
+	all         bool
 }
 
 func cmdList(ctx context.Context, sherlock *internal.Sherlock) *cobra.Command {
@@ -19,10 +20,21 @@ func cmdList(ctx context.Context, sherlock *internal.Sherlock) *cobra.Command {
 		Use:   "list",
 		Short: "list all accounts mapped to a given group",
 		Long:  "with the list command you can inspect all accounts mapped to a given group",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.MaximumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			var gid = "default"
-			if len(args) > 0 {
+			if opts.all {
+				groupList, err := sherlock.ReadRegisteredGroups()
+				if err != nil {
+					terminal.Error(err.Error())
+					return
+				}
+				terminal.Info("Registered Groups : ")
+				for _, group := range groupList {
+					terminal.Info(group)
+				}
+				return
+			} else if len(args) > 0 {
 				gid = args[0]
 			}
 			groupKey, err := terminal.ReadPassword("(%s) password: ", gid)
@@ -45,6 +57,7 @@ func cmdList(ctx context.Context, sherlock *internal.Sherlock) *cobra.Command {
 		},
 	}
 	list.Flags().StringVarP(&opts.filterByTag, "tag", "t", "", "filter accounts by tag name")
+	list.Flags().BoolVarP(&opts.all, "all", "a", false, "show all registered groups")
 
 	return list
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -120,3 +120,16 @@ func homepath() string {
 	home, _ := os.UserHomeDir()
 	return home
 }
+
+// Read All Groups Saved
+func (fs Fs) ReadRegisteredGroups() ([]string, error) {
+	groupList, err := afero.ReadDir(fs.mock, buildGroupPath(""))
+	if err != nil {
+		return nil, err
+	}
+	var groupListNames []string
+	for _, f := range groupList {
+		groupListNames = append(groupListNames, f.Name())
+	}
+	return groupListNames, nil
+}

--- a/internal/sherlock.go
+++ b/internal/sherlock.go
@@ -83,6 +83,7 @@ type FileSystem interface {
 	VaultExists(group string) error
 	ReadGroupVault(group string) ([]byte, error)
 	Write(ctx context.Context, gid string, data []byte) error
+	ReadRegisteredGroups() ([]string, error)
 }
 
 type Sherlock struct {
@@ -235,4 +236,13 @@ func splitQuery(query string) (string, string, error) {
 		return "", "", ErrInvalidQuery
 	}
 	return set[0], set[1], nil
+}
+
+// ReadRegisteredGroups loads saved groups
+func (sh Sherlock) ReadRegisteredGroups() ([]string, error) {
+	groups, err := sh.fileSystem.ReadRegisteredGroups()
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
 }


### PR DESCRIPTION
This PR is related to issue #19 
show all saved groups with command
`sherlock list -a`
or
`sherlock list --all`

https://user-images.githubusercontent.com/10482274/126519285-494e8067-8d65-42c9-8f10-a688f5ad890a.mp4

